### PR TITLE
Pick correctly library on aarch64

### DIFF
--- a/rhasspywake_porcupine_hermes/__main__.py
+++ b/rhasspywake_porcupine_hermes/__main__.py
@@ -83,7 +83,7 @@ def main():
     # Add embedded keywords too
     keyword_base = _DIR / "porcupine" / "resources" / "keyword_files"
 
-    if machine in ["armv6l", "armv7l", "armv8"]:
+    if machine in ["armv6l", "armv7l", "armv8", "aarch64"]:
         # Raspberry Pi
         args.keyword_dir.append(keyword_base / "raspberrypi")
     else:
@@ -107,7 +107,7 @@ def main():
         if machine == "armv6l":
             # Pi 0/1
             lib_dir = os.path.join(lib_dir, "raspberry-pi", "arm11")
-        elif machine in ["armv7l", "armv8"]:
+        elif machine in ["armv7l", "armv8", "aarch64"]:
             # Pi 2 uses Cortex A7
             # Pi 3 uses Cortex A53
             # Pi 4 uses Cortex A72


### PR DESCRIPTION
My Raspberry Pi4 running NixOS identifies as aarch64 and is therefore
currently erroneously trying to load the x86_64 library.

```pytb
Traceback (most recent call last):
  File "/nix/store/s8dycck74v5chdk449qsydhh8d8x9m61-python3.8-rhasspy-wake-porcupine-hermes-2020-06-05/bin/.rhasspy-wake-porcupine-hermes-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/s8dycck74v5chdk449qsydhh8d8x9m61-python3.8-rhasspy-wake-porcupine-hermes-2020-06-05/lib/python3.8/site-packages/rhasspywake_porcupine_hermes/__main__.py", line 138, in main
    porcupine_handle = Porcupine(
  File "/nix/store/s8dycck74v5chdk449qsydhh8d8x9m61-python3.8-rhasspy-wake-porcupine-hermes-2020-06-05/lib/python3.8/site-packages/rhasspywake_porcupine_hermes/porcupine.py", line 72, in __init__
    library = cdll.LoadLibrary(library_path)
  File "/nix/store/v1sf9gklafal3ycf1fgxv7v2mxa2y195-python3-3.8.3/lib/python3.8/ctypes/__init__.py", line 451, in LoadLibrary
    return self._dlltype(name)
  File "/nix/store/v1sf9gklafal3ycf1fgxv7v2mxa2y195-python3-3.8.3/lib/python3.8/ctypes/__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /nix/store/s8dycck74v5chdk449qsydhh8d8x9m61-python3.8-rhasspy-wake-porcupine-hermes-2020-06-05/lib/python3.8/site-packages/rhasspywake_porcupine_hermes/porcupine/lib/linux/x86_64/libpv_porcupine.so: cannot open shared object file: No such file or directory
```

```py3
>>> import platform
>>> platform.machine()
'aarch64'
```