### PR TITLE
Porcupine v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ $ bin/rhasspy-wake-porcupine-hermes <ARGS>
 
 ```
 usage: rhasspy-wake-porcupine-hermes [-h] --keyword KEYWORD
+                                     [--access-key ACCESS_KEY]
                                      [--keyword-dir KEYWORD_DIR]
-                                     [--library LIBRARY] [--model MODEL]
+                                     [--library LIBRARY]
+                                     [--model MODEL]
                                      [--wakeword-id WAKEWORD_ID]
                                      [--sensitivity SENSITIVITY]
                                      [--stdin-audio]
@@ -50,12 +52,15 @@ usage: rhasspy-wake-porcupine-hermes [-h] --keyword KEYWORD
 
 optional arguments:
   -h, --help            show this help message and exit
+  --access-key ACCESS_KEY
+                        Porcupine access key
   --keyword KEYWORD     Path(s) to one or more Porcupine keyword file(s)
                         (.ppn)
   --keyword-dir KEYWORD_DIR
                         Path to directory with keyword files
   --library LIBRARY     Path to Porcupine shared library (.so)
-  --model MODEL         Path to Porcupine model (.pv)
+  --model MODEL         Absolute path to the file containing model parameters (.pv)
+                        Default: using the library provided by `pvporcupine`
   --wakeword-id WAKEWORD_ID
                         Wakeword IDs of each keyword (default: use file name)
   --sensitivity SENSITIVITY

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 paho-mqtt==1.5.0
-pvporcupine~=1.9.0
+pvporcupine~=2.2.1
 rhasspy-hermes~=0.6.0

--- a/rhasspywake_porcupine_hermes/__main__.py
+++ b/rhasspywake_porcupine_hermes/__main__.py
@@ -25,6 +25,11 @@ def main():
     """Main method."""
     parser = argparse.ArgumentParser(prog="rhasspy-wake-porcupine-hermes")
     parser.add_argument(
+        "--access-key",
+        required=True,
+        help="Porcupine access key",
+    )
+    parser.add_argument(
         "--keyword",
         required=True,
         action="append",
@@ -40,6 +45,11 @@ def main():
         "--wakeword-id",
         action="append",
         help="Wakeword IDs of each keyword (default: use file name)",
+    )
+    parser.add_argument(
+        "--model",
+        help="Absolute path to the file containing model parameters (.pv)"
+             "Default: using the library provided by `pvporcupine`"
     )
     parser.add_argument(
         "--sensitivity",
@@ -69,7 +79,6 @@ def main():
 
     # --- DEPRECATED (using pvporcupine now) ---
     parser.add_argument("--library", help="Path to Porcupine shared library (.so)")
-    parser.add_argument("--model", help="Path to Porcupine model (.pv)")
     # --- DEPRECATED (using pvporcupine now) ---
 
     hermes_cli.add_hermes_args(parser)
@@ -164,6 +173,7 @@ def main():
     client = mqtt.Client()
     hermes = WakeHermesMqtt(
         client,
+        args.access_key,
         args.keyword,
         keyword_names,
         sensitivities,
@@ -173,6 +183,7 @@ def main():
         udp_forward_mqtt=args.udp_forward_mqtt,
         site_ids=args.site_id,
         lang=args.lang,
+        model_path=args.model,
     )
 
     _LOGGER.debug("Connecting to %s:%s", args.host, args.port)


### PR DESCRIPTION
Upgrade to the latest version of Porcupine where an "Access Key" is needed to use the SDK.

Solves #10.

This PR is coupled with the following one:  https://github.com/rhasspy/rhasspy-supervisor/pull/11

Until the PRs are merged, the latest porcupine in Rhasspy can be tested by compiling from sources as described [here](https://github.com/asmirnou/rhasspy/wiki#porcupine-v2-support). 
